### PR TITLE
Add missing python3 dependency

### DIFF
--- a/gen-nodejs-runner.sh
+++ b/gen-nodejs-runner.sh
@@ -71,7 +71,7 @@ RUN chmod +x go.sh
 
 # Install gitlab-runner and nodejs
 RUN apt-get update && \\
-    apt-get install -y curl && \\
+    apt-get install -y curl python3 && \\
     curl -L https://packages.gitlab.com/install/repositories/runner/gitlab-runner/script.deb.sh | bash  && \\
     apt-get install -y gitlab-runner && \\
     curl -sL https://deb.nodesource.com/setup_9.x | bash  && \\


### PR DESCRIPTION
Required to run the web server at the end of the `go.sh` script